### PR TITLE
Added administration option for public/private access

### DIFF
--- a/AmazonS3StreamWrapper.inc
+++ b/AmazonS3StreamWrapper.inc
@@ -70,6 +70,11 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
   protected $caching = FALSE;
 
   /**
+   * @var boolean Whether to allow public access to uploaded files
+   */
+  protected $public_access = FALSE;
+
+  /**
    * @var array Map for files that should be delivered with a torrent URL.
    */
   protected $torrents = array();
@@ -111,6 +116,11 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
     // Check whether local file caching is turned on
     if (variable_get('amazons3_cache', FALSE)) {
       $this->caching = TRUE;
+    }
+
+    // Check whether public access turned on
+    if (variable_get('amazons3_public_access', FALSE)) {
+      $this->public_access = TRUE;
     }
 
     // Torrent list
@@ -552,7 +562,7 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
     if($this->write_buffer) {
       $response = $this->getS3()->create_object($this->bucket, $this->getLocalPath(), array(
         'body' => $this->buffer,
-        'acl' => AmazonS3::ACL_PUBLIC,
+        'acl' => ($this->public_access) ? AmazonS3::ACL_PUBLIC : AmazonS3::ACL_PRIVATE,
         'contentType' => AmazonS3StreamWrapper::getMimeType($this->uri),
       ));
       if($response->isOK()) {
@@ -647,7 +657,7 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
     $response = $s3->copy_object(
       array('bucket' => $this->bucket, 'filename' => $from),
       array('bucket' => $this->bucket, 'filename' => $to),
-      array('acl' => AmazonS3::ACL_PUBLIC)
+      array('acl' => ($this->public_access) ? AmazonS3::ACL_PUBLIC : AmazonS3::ACL_PRIVATE)
     );
     if (!$response->isOK()) {
       return FALSE;

--- a/amazons3.module
+++ b/amazons3.module
@@ -82,6 +82,13 @@ function amazons3_admin() {
     '#description'    => t('Enable a local file metadata cache, this significantly reduces calls to S3'),
     '#default_value'  => variable_get('amazons3_cache', 1),
   );
+  
+  $form['amazons3_public_access'] = array(
+    '#type'           => 'checkbox',
+    '#title'          => t('Enable public access'),
+    '#description'    => t('This will set the S3 object permissions to everyone'),
+    '#default_value'  => variable_get('amazons3_public_access', 1),
+  );
 
   $form['amazons3_cname'] = array(
     '#type'           => 'checkbox',

--- a/amazons3.module
+++ b/amazons3.module
@@ -149,7 +149,13 @@ function amazons3_admin() {
 
 function amazons3_admin_validate($form, &$form_state) {
   $bucket = $form_state['values']['amazons3_bucket'];
-
+  $public_access = $form_state['values']['amazons3_public_access'];
+  $presigned_urls = $form_state['values']['amazons3_presigned_urls'];
+  
+  if($public_access !== "1" && $presigned_urls === "") {
+    form_set_error('amazons3_presigned_urls', t('If you wish to block public access to S3 objects you must set at least 1 Presigned URL'));
+  } 
+  
   if(!libraries_load('awssdk')) {
     form_set_error('amazons3_bucket', t('Unable to load the AWS SDK. Please check you have installed the library correctly and configured your S3 credentials.'));
   }


### PR DESCRIPTION
I have added a checkbox in admin for public access, this will switch the ACL_PRIVATE and ACL_PUBLIC flags in the stream_flush and copy functions allowing people to upload files but not download.

To allow users to download you can use the presigned urls area and set a timeout yourself.
