### PR TITLE
Better non-Amazon S3 support (including Ceph)

### DIFF
--- a/AmazonS3StreamWrapper.inc
+++ b/AmazonS3StreamWrapper.inc
@@ -1,4 +1,5 @@
 <?php
+require_once 'amazons3.aws.inc';
 
 /**
  * @file
@@ -120,6 +121,8 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
   public function __construct() {
     $this->hostname = variable_get('amazons3_hostname', '');
     $this->bucket = $bucket = variable_get('amazons3_bucket', '');
+    $this->use_ssl = variable_get('amazons3_ssl', 1);
+    $scheme = $this->use_ssl ? 'https://' : 'http://';
 
     // CNAME support for customising S3 URLs.
     if (variable_get('amazons3_cname', 0)) {
@@ -130,11 +133,10 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
       else {
         $this->domain = '//' . $this->bucket;
       }
-
       $this->cloudfront = variable_get('amazons3_cloudfront', TRUE);
     }
     else {
-      $this->domain = '//' . $this->bucket . '.s3.amazonaws.com';
+      $this->domain = $this->__getBucketPathBaseURL();
     }
 
     // Check whether local file caching is turned on.
@@ -184,6 +186,44 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
 
   }
 
+  /**
+   * Return the constructed hostname to use for reaching S3
+   *
+   * One of the following formats:
+   * - //hostname.resource-prefix
+   * - //hostname.resource-prefix.bucket
+   * - //vhost
+   * - //hostname
+   * - //hostname.bucket
+   *
+   * @return string
+   *   Returns a string containing a web accessible base URL for the bucket
+   */
+  protected function __getBucketPathBaseURL() {
+      $s3 = $this->getS3();
+      $bucket = $this->bucket;
+      /* Start of code borrowed & modified from the AmazonS3::authenticate */
+      // If the bucket name has periods and we are using SSL, we need to switch to path style URLs
+      $bucket_name_may_cause_ssl_wildcard_failures = false;
+      if ($s3->use_ssl && strpos($bucket, '.') !== false)
+      {
+          $bucket_name_may_cause_ssl_wildcard_failures = true;
+      }
+      // Determine hostname
+      $scheme = $s3->use_ssl ? 'https://' : 'http://';
+      if ($bucket_name_may_cause_ssl_wildcard_failures || $s3->resource_prefix || $s3->path_style)
+      {
+          // Use bucket-in-path method
+          $hostname = $s3->hostname . $s3->resource_prefix . (($bucket === '' || $s3->resource_prefix === '/' . $bucket) ? '' : ('/' . $bucket));
+      }
+      else
+      {
+          $hostname = $s3->vhost ? $s3->vhost : (($bucket === '') ? $s3->hostname : ($bucket . '.') . $s3->hostname);
+      }
+      /* End of borrowed code */
+      //return '//'.$hostname;
+      return $scheme.$hostname;
+  }
 
   /**
    * Sets the stream resource URI.
@@ -1014,11 +1054,7 @@ class AmazonS3StreamWrapper implements DrupalStreamWrapperInterface {
       }
       else {
         try {
-          $this->s3 = new AmazonS3();
-          if (!empty($this->hostname)) {
-            $this->s3->set_hostname($this->hostname);
-            $this->s3->allow_hostname_override(FALSE);
-          }
+          $this->s3 = CreateS3Instance();
         }
         catch (Exception $e) {
           drupal_set_message(t('There was a problem using S3. @message', array('message' => $e->getMessage())), 'error');

--- a/amazons3.api.php
+++ b/amazons3.api.php
@@ -37,13 +37,13 @@ function hook_amazons3_url_info($local_path, $info) {
     $info['presigned_url'] = TRUE;
     $info['presigned_url_timeout'] = 10;
   }
-  
+
   $cache_time = 60 * 60 * 5;
   $info['response'] = array(
     'Cache-Control' => 'max-age=' . $cache_time . ', must-revalidate',
     'Expires' => gmdate('D, d M Y H:i:s', time() + $cache_time) . ' GMT',
   );
-  
+
   return $info;
 }
 

--- a/amazons3.aws.inc
+++ b/amazons3.aws.inc
@@ -9,7 +9,7 @@
  * You are responsible for loading the awssdk library beforehand YOURSELF.
  */
 function CreateS3Instance() {
-	$s3 = new AmazonS3();
+  $s3 = new AmazonS3();
   // Custom S3 setup
   $hostname = variable_get('amazons3_hostname', '');
   if (!empty($hostname)) {
@@ -21,9 +21,11 @@ function CreateS3Instance() {
     //$this->s3->disable_ssl();
     $s3->use_ssl = false; // disable_ssl spews a warning
   }
-  if (variable_get('amazons3_path_style', 0)) {
+  $path = variable_get('amazons3_path_style', 0);
+  if ($path != 0) {
     $s3->enable_path_style();
   }
+  drupal_set_message(t('hostname=@hostname; ssl=@ssl; path=@path', array('@hostname'=>$hostname, '@ssl'=>$ssl, '@path' => $path)));
   return $s3;
 }
 

--- a/amazons3.aws.inc
+++ b/amazons3.aws.inc
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @file
+ * Provides a common instantior for the AmazonS3 class with common settings
+ */
+
+/**
+ * Return the constructed hostname to use for reaching S3
+ * You are responsible for loading the awssdk library beforehand YOURSELF.
+ */
+function CreateS3Instance() {
+	$s3 = new AmazonS3();
+  // Custom S3 setup
+  $hostname = variable_get('amazons3_hostname', '');
+  if (!empty($hostname)) {
+    $s3->set_hostname($hostname);
+    $s3->allow_hostname_override(FALSE);
+  }
+  $ssl = variable_get('amazons3_ssl', 1);
+  if ($ssl == 0) {
+    //$this->s3->disable_ssl();
+    $s3->use_ssl = false; // disable_ssl spews a warning
+  }
+  if (variable_get('amazons3_path_style', 0)) {
+    $s3->enable_path_style();
+  }
+  return $s3;
+}
+
+?>

--- a/amazons3.aws.inc
+++ b/amazons3.aws.inc
@@ -25,7 +25,7 @@ function CreateS3Instance() {
   if ($path != 0) {
     $s3->enable_path_style();
   }
-  drupal_set_message(t('hostname=@hostname; ssl=@ssl; path=@path', array('@hostname'=>$hostname, '@ssl'=>$ssl, '@path' => $path)));
+  //drupal_set_message(t('hostname=@hostname; ssl=@ssl; path=@path', array('@hostname'=>$hostname, '@ssl'=>$ssl, '@path' => $path)));
   return $s3;
 }
 

--- a/amazons3.info
+++ b/amazons3.info
@@ -5,6 +5,7 @@ package = Amazon S3
 core = 7.x
 files[] = amazons3.module
 files[] = AmazonS3StreamWrapper.inc
+files[] = amazons3.aws.inc
 dependencies[] = awssdk (>=5.1)
 dependencies[] = libraries (2.x)
 configure = admin/config/media/amazons3

--- a/amazons3.install
+++ b/amazons3.install
@@ -43,6 +43,8 @@ function amazons3_uninstall() {
   variable_del('amazons3_rrs');
   variable_del('amazons3_https');
   variable_del('amazons3_hostname');
+  variable_del('amazons3_path_style');
+  variable_del('amazons3_ssl');
 }
 
 /**

--- a/amazons3.module
+++ b/amazons3.module
@@ -216,6 +216,7 @@ function amazons3_admin_validate($form, &$form_state) {
   else {
     try {
       $s3 = CreateS3Instance();
+      // Check for bucket
       // Check for objects
       $response = $s3->list_objects($bucket, array(
           'max-keys' => 1,

--- a/amazons3.module
+++ b/amazons3.module
@@ -1,4 +1,5 @@
 <?php
+require_once 'amazons3.aws.inc';
 
 /**
  * @file
@@ -119,8 +120,22 @@ function amazons3_admin() {
   $form['amazons3_hostname'] = array(
     '#type' => 'textfield',
     '#title' => t('Custom Hostname'),
-    '#description' => t('For use with an alternative API compatible service e.g. <a href="@cloud">Google Cloud Storage</a>', array('@cloud' => 'https://cloud.google.com/storage‎')),
+    '#description' => t('For use with an alternative API compatible service e.g. <a href="@cloud">Google Cloud Storage</a>', array('@cloud' => 'https://cloud.google.com/storage')),
     '#default_value' => variable_get('amazons3_hostname', ''),
+  );
+
+  $form['amazons3_ssl'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable SSL'),
+    '#default_value' => variable_get('amazons3_ssl', 1),
+    '#description' => t('Enable use of SSL when communicating with S3 provider'),
+  );
+
+  $form['amazons3_path_style'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable path-style.'),
+    '#default_value' => variable_get('amazons3_path_style', 0),
+    '#description' => t('Use path-style S3 accesses with S3 provider'),
   );
 
   $form['amazons3_https'] = array(
@@ -200,7 +215,8 @@ function amazons3_admin_validate($form, &$form_state) {
   }
   else {
     try {
-      $s3 = new AmazonS3();
+      $s3 = CreateS3Instance();
+      // Check for objects
       $response = $s3->list_objects($bucket, array(
           'max-keys' => 1,
         ));


### PR DESCRIPTION
- Hostname was not overwritten in validation.
- Support older S3 path-style access //$HOSTNAME/$BUCKET/
- Make it possible to entirely disable S3 if your provider does not
  support it.

Confirmed working with Ceph RADOSGW v0.77-1raring.

Signed-off-by: Robin H. Johnson rjohnson@sitka.bclibraries.ca
