### PR TITLE
Issue #2471835: Add Matchable classes for config path matching.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 build
+phpunit.xml

--- a/src/Matchable/BasicPath.php
+++ b/src/Matchable/BasicPath.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\amazons3\Matchable;
+
+/**
+ * A path pattern to use when testing URL paths.
+ *
+ * @class BasicPath
+ * @package Drupal\amazons3\Matchable
+ */
+class BasicPath implements Matchable {
+  use MatchableRegex;
+
+  /**
+   * The path pattern for this presigned path configuration.
+   *
+   * @var string
+   */
+  protected $pattern;
+
+  /**
+   * Create an array of BasicPaths.
+   *
+   * @param array $patterns
+   *   An array of regular expression patterns to use when creating the basic
+   *   path.
+   *
+   * @return BasicPath[]
+   *   An array of BasicPaths.
+   */
+  public static function factory(array $patterns) {
+    $basicPaths = array();
+    foreach ($patterns as $pattern) {
+      $basicPaths[] = new static($pattern);
+    }
+
+    return $basicPaths;
+  }
+
+  /**
+   * Construct a new BasicPath.
+   *
+   * @param $pattern
+   *   An regular expression pattern, without start and end markers.
+   */
+  public function __construct($pattern) {
+    $result = @preg_match('#' . strtr($pattern, '#', '\#') . '#', 'foo');
+    if ($result === FALSE || preg_last_error() != PREG_NO_ERROR) {
+      throw new \InvalidArgumentException('BasicPath pattern is not a valid regular expression.');
+    }
+
+    $this->pattern = $pattern;
+  }
+
+  /**
+   * @return string
+   */
+  public function getPath() {
+    return $this->pattern;
+  }
+
+  /**
+   * @return string
+   */
+  function __toString() {
+    return $this->pattern;
+  }
+}

--- a/src/Matchable/BasicPath.php
+++ b/src/Matchable/BasicPath.php
@@ -45,7 +45,7 @@ class BasicPath implements Matchable {
    */
   public function __construct($pattern) {
     $result = @preg_match('#' . strtr($pattern, '#', '\#') . '#', 'foo');
-    if ($result === FALSE || preg_last_error() != PREG_NO_ERROR) {
+    if ($pattern != '*' && ($result === FALSE || preg_last_error() != PREG_NO_ERROR)) {
       throw new \InvalidArgumentException('BasicPath pattern is not a valid regular expression.');
     }
 

--- a/src/Matchable/Matchable.php
+++ b/src/Matchable/Matchable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\amazons3\Matchable;
+
+/**
+ * Interface for objects that can be matched against a given string.
+ *
+ * @package Drupal\amazons3\Matchable
+ */
+interface Matchable {
+
+  /**
+   * Match this object against a string.
+   *
+   * Typically, this will be done with a basic string contains, glob, or regular
+   * expression.
+   *
+   * @param string $subject
+   *   The string to match against.
+   *
+   * @return Matchable|bool
+   *   The object that matched, or FALSE if no match was found.
+   */
+  public function match($subject);
+}

--- a/src/Matchable/MatchablePaths.php
+++ b/src/Matchable/MatchablePaths.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\amazons3\Matchable;
+
+/**
+ * A list of paths that can be matched against a regular expression.
+ *
+ * @class MatchablePaths
+ * @package Drupal\amazons3\Matchable
+ */
+class MatchablePaths implements Matchable {
+
+  /**
+   * An array of paths to match against.
+   *
+   * @var Matchable[]
+   */
+  protected $paths;
+
+  /**
+   * Construct a new set of MatchablePaths.
+   *
+   * @param Matchable[] $paths
+   *   An array of Matchable objects.
+   */
+  public function __construct(array $paths = array()) {
+    $this->paths = $paths;
+  }
+
+  /**
+   * Return the first object that matches a subject.
+   *
+   * {@inheritdoc}
+   */
+  public function match($subject) {
+    foreach ($this->paths as $path) {
+      if ($path->match($subject)) {
+        return $path;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __toString() {
+    return implode('|', $this->paths);
+  }
+}

--- a/src/Matchable/MatchableRegex.php
+++ b/src/Matchable/MatchableRegex.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\amazons3\Matchable;
+
+/**
+ * Base class for objects that can be matched against a regular expression.
+ *
+ * This class also handles '*' to mean 'any string'.
+ *
+ * @class MatchableRegex
+ * @package Drupal\amazons3\Matchable
+ */
+trait MatchableRegex {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function match($subject) {
+    $pattern = $this->__toString();
+    if ($pattern === '*' || preg_match('#' . strtr($pattern, '#', '\#') . '#', $subject)) {
+      return $this;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Return the pattern this object matches against.
+   *
+   * @return string
+   */
+  abstract public function __toString();
+}

--- a/src/Matchable/PresignedPath.php
+++ b/src/Matchable/PresignedPath.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\amazons3\Matchable;
+
+/**
+ * @class PresignedPath
+ * @package Drupal\amazons3
+ */
+class PresignedPath extends BasicPath {
+
+  /**
+   * The timeout for URLs generated from this presigned path.
+   *
+   * @var int
+   */
+  protected $timeout;
+
+  /**
+   * @param $pattern
+   * @param $timeout
+   */
+  public function __construct($pattern, $timeout) {
+    $this->pattern = $pattern;
+    $this->timeout = $timeout;
+  }
+
+  /**
+   * @return string
+   */
+  public function getPath() {
+    return $this->pattern;
+  }
+
+  /**
+   * @return int
+   */
+  public function getTimeout() {
+    return $this->timeout;
+  }
+}

--- a/tests/Matchable/BasicPathTest.php
+++ b/tests/Matchable/BasicPathTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\amazons3Test\Matchable;
+
+use Drupal\amazons3\Matchable\BasicPath;
+
+/**
+ * @class BasicPathTest
+ * @package Drupal\amazons3Test\Matchable
+ */
+class BasicPathTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * @covers Drupal\amazons3\Matchable\BasicPath::factory
+   * @covers Drupal\amazons3\Matchable\BasicPath::__construct
+   * @covers Drupal\amazons3\Matchable\BasicPath::getPath
+   */
+  public function testFactory() {
+    $paths = BasicPath::factory(array('.*', '.?'));
+    $this->assertTrue(is_array($paths));
+    foreach ($paths as $path) {
+      $this->assertInstanceOf('Drupal\amazons3\Matchable\BasicPath', $path);
+    }
+    $this->assertEquals('.*', $paths[0]->getPath());
+    $this->assertEquals('.?', $paths[1]->getPath());
+  }
+
+  /**
+   * @covers Drupal\amazons3\Matchable\BasicPath::__toString
+   */
+  public function testToString() {
+    $path = new BasicPath('.*');
+    $this->assertEquals($path->getPath(), (string) $path);
+  }
+
+  /**
+   * @covers Drupal\amazons3\Matchable\BasicPath::__construct
+   * @expectedException \InvalidArgumentException
+   */
+  public function testInvalidPattern() {
+    new BasicPath('?');
+  }
+}

--- a/tests/Matchable/BasicPathTest.php
+++ b/tests/Matchable/BasicPathTest.php
@@ -40,4 +40,12 @@ class BasicPathTest extends \PHPUnit_Framework_TestCase {
   public function testInvalidPattern() {
     new BasicPath('?');
   }
+
+  /**
+   * @covers Drupal\amazons3\Matchable\BasicPath::__construct
+   */
+  public function testStarPattern() {
+    $path = new BasicPath('*');
+    $this->assertSame($path, $path->match('foo'));
+  }
 }

--- a/tests/Matchable/BasicPathTest.php
+++ b/tests/Matchable/BasicPathTest.php
@@ -48,4 +48,13 @@ class BasicPathTest extends \PHPUnit_Framework_TestCase {
     $path = new BasicPath('*');
     $this->assertSame($path, $path->match('foo'));
   }
+
+  /**
+   * @covers Drupal\amazons3\Matchable\MatchableRegex::match
+   */
+  public function testRegexMatching() {
+    $path = new BasicPath('^ab$');
+    $this->assertSame($path, $path->match('ab'));
+    $this->assertFalse($path->match('yz'));
+  }
 }

--- a/tests/Matchable/MatchablePathsTest.php
+++ b/tests/Matchable/MatchablePathsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\amazons3Test\Matchable;
+
+use Drupal\amazons3\Matchable\BasicPath;
+use Drupal\amazons3\Matchable\MatchablePaths;
+
+class MatchablePathsTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * @covers Drupal\amazons3\Matchable\MatchablePaths::__construct
+   * @covers Drupal\amazons3\Matchable\MatchablePaths::__toString
+   */
+  public function testImplode() {
+    $mp = new MatchablePaths(BasicPath::factory(array('.*', '.?')));
+    $this->assertEquals('.*|.?', (string) $mp);
+  }
+
+  /**
+   * @covers Drupal\amazons3\Matchable\MatchablePaths::match
+   */
+  public function testMatch() {
+    $paths = BasicPath::factory(array('foo', 'bar'));
+    $mp = new MatchablePaths($paths);
+    $this->assertSame($paths[0], $mp->match('foo'));
+    $this->assertSame($paths[1], $mp->match('bar'));
+  }
+
+  /**
+   * @covers Drupal\amazons3\Matchable\MatchablePaths::match
+   */
+  public function testNoMatch() {
+    $paths = BasicPath::factory(array('foo', 'bar'));
+    $mp = new MatchablePaths($paths);
+    $this->assertFalse($mp->match('no-match'));
+  }
+}

--- a/tests/Matchable/PresignedPathTest.php
+++ b/tests/Matchable/PresignedPathTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\amazons3Test\Matchable;
+
+use Drupal\amazons3\Matchable\PresignedPath;
+
+/**
+ * @class PresignedPathTest
+ * @package Drupal\amazons3Test\Matchable
+ */
+class PresignedPathTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * Test getters and setters on PresignedPaths.
+   *
+   * @covers Drupal\amazons3\Matchable\PresignedPath::__construct
+   * @covers Drupal\amazons3\Matchable\PresignedPath::getPath
+   * @covers Drupal\amazons3\Matchable\PresignedPath::getTimeout
+   */
+  public function testGetters() {
+    $p = new PresignedPath('images/.*', 30);
+    $this->assertEquals('images/.*', $p->getPath());
+    $this->assertEquals(30, $p->getTimeout());
+  }
+}


### PR DESCRIPTION
There's a common pattern in Drupal modules where we have some bit of user configuration that ends up being a text blob with globs or regular expressions. This PR adds classes that I will use in a followup to determine if a given S3 URL matches a torrent path, save as path, and so on.

I think I will probably pull this out into a separate library for everything other than the PresignedURL class, but it's here for now.
