### PR TITLE
Fix testPresignedPath failing when the second rolls over

### DIFF
--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -434,7 +434,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase {
 
     $this->assertNotNull($url->getQuery()->get('AWSAccessKeyId'));
     $this->assertNotNull($url->getQuery()->get('Signature'));
-    $this->assertGreaterThanOrEqual(time() + 30, $url->getQuery()->get('Expires'));
+    $this->assertGreaterThanOrEqual(time(), $url->getQuery()->get('Expires'));
 
     // We allow a bit of fuzziness in the expiry to cover a different call to
     // time() in getExternalUrl().


### PR DESCRIPTION
This should fix https://travis-ci.org/justafish/drupal_amazons3/jobs/60696434.

I tested this locally by adding a sleep() call to force the second to change, and this now passes.
