### PR TITLE
Fix missing bucket name when a bucket does not contain a dot.

### DIFF
--- a/src/StreamWrapperConfiguration.php
+++ b/src/StreamWrapperConfiguration.php
@@ -63,6 +63,12 @@ class StreamWrapperConfiguration extends Collection {
 
     if (!$data['domain']) {
       $data['domain'] = 's3.amazonaws.com';
+
+      // If the bucket does not contain dots, the S3 SDK generates URLs that
+      // use the bucket name in the host.
+      if (strpos($data['bucket'], '.') === FALSE) {
+        $data['domain'] = $data['bucket'] . '.' . $data['domain'];
+      }
     }
 
     return new static($data);

--- a/tests/StreamWrapperConfigurationTest.php
+++ b/tests/StreamWrapperConfigurationTest.php
@@ -118,7 +118,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    */
   public function testDefaultHostname() {
     $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket'));
-    $this->assertEquals('s3.amazonaws.com', $config->getDomain());
+    $this->assertEquals('bucket.s3.amazonaws.com', $config->getDomain());
   }
 
   /**


### PR DESCRIPTION
Fixes Github issue #22.
