### PR TITLE
Issue #2565469: Let users specify a region

### DIFF
--- a/amazons3.admin.inc
+++ b/amazons3.admin.inc
@@ -28,6 +28,16 @@ function amazons3_admin() {
     '#element_validate' => array('amazons3_form_bucket_validate'),
   );
 
+  $client = \Aws\S3\S3Client::factory();
+
+  $form['amazons3_region'] = array(
+    '#type' => 'select',
+    '#title' => t('Default region'),
+    '#default_value' => variable_get('amazons3_region', ''),
+    '#required' => TRUE,
+    '#options' => array_combine(array_keys($client->getRegions()), array_keys($client->getRegions())),
+  );
+
   $form['amazons3_cache'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable metadata caching'),

--- a/amazons3.module
+++ b/amazons3.module
@@ -566,6 +566,7 @@ function _amazons3_field_configuration(array &$form, $type) {
     if ($type == $types) {
       $settings = &$form['field']['settings'];
       $bucket_setting = isset($form['#field']['settings']['amazons3_bucket']) ? $form['#field']['settings']['amazons3_bucket'] : '';
+      $region_setting = isset($form['#field']['settings']['amazons3_region']) ? $form['#field']['settings']['amazons3_region'] : '';
 
       $settings['uri_scheme']['#weight'] = 50;
 
@@ -586,6 +587,28 @@ function _amazons3_field_configuration(array &$form, $type) {
         ),
         '#default_value' => $bucket_setting,
         '#element_validate' => array('amazons3_form_bucket_validate'),
+        '#weight' => 51,
+      );
+
+      $client = \Aws\S3\S3Client::factory();
+
+      $settings['amazons3_region'] = array(
+        '#type' => 'select',
+        '#title' => t('Amazon S3 region'),
+        '#description' => t(
+          'Use <em>default region</em> to use the site-wide default region <a href="@config">currently set to %region</a>.',
+          array(
+            '@config' => url('admin/config/media/amazons3'),
+            '%region' => variable_get('amazons3_region', ''),
+          )
+        ),
+        '#states' => array(
+          'visible' => array(
+            ':input[name="field[settings][uri_scheme]"]' => array('value' => 's3'),
+          ),
+        ),
+        '#default_value' => $region_setting,
+        '#options' => array(0 => t('- default region -')) + array_combine(array_keys($client->getRegions()), array_keys($client->getRegions())),
         '#weight' => 51,
       );
     }
@@ -619,6 +642,13 @@ function amazons3_form_bucket_validate(array &$element, array &$form_state, arra
   $config = array();
   if (isset($form_state['values']['amazons3_key']) && isset($form_state['values']['amazons3_secret'])) {
     $config['credentials'] = new Credentials($form_state['values']['amazons3_key'], $form_state['values']['amazons3_secret']);
+  }
+
+  if (isset($form_state['values']['amazons3_region'])) {
+    $config['region'] = $form_state['values']['amazons3_region'];
+  }
+  elseif (isset($form_state['values']['field']['settings']['amazons3_region']) && $form_state['values']['field']['settings']['amazons3_region']) {
+    $config['region'] = $form_state['values']['field']['settings']['amazons3_region'];
   }
 
   if (!empty($hostname)) {

--- a/src/S3Client.php
+++ b/src/S3Client.php
@@ -92,16 +92,15 @@ class S3Client {
 
     $config['curl.options'] += $curl_defaults;
 
-    $client = AwsS3Client::factory($config);
-
     // Set the default client location to the associated bucket.
-    if (!isset($config['region']) && $bucket) {
-      $region = static::getBucketLocation($bucket, $client);
-      if (!empty($region) && $client->getRegion() != $region) {
+    if (!isset($config['region'])) {
+      $region = static::variable_get('amazons3_region');
+      if (!empty($region)) {
         $config['region'] = $region;
-        $client = AwsS3Client::factory($config);
       }
     }
+
+    $client = AwsS3Client::factory($config);
 
     static::setCommandFactory($client);
 

--- a/src/StreamWrapperConfiguration.php
+++ b/src/StreamWrapperConfiguration.php
@@ -75,7 +75,7 @@ class StreamWrapperConfiguration extends Collection {
     $defaults = array(
       'hostname' => NULL,
       'bucket' => NULL,
-      'region' => 'us-east-1',
+      'region' => NULL,
       'torrentPaths' => new MatchablePaths(),
       'presignedPaths' => new MatchablePaths(),
       'saveAsPaths' => new MatchablePaths(),
@@ -96,6 +96,7 @@ class StreamWrapperConfiguration extends Collection {
   protected static function required() {
     $required = array(
       'bucket',
+      'region',
     );
     return $required;
   }
@@ -369,7 +370,10 @@ class StreamWrapperConfiguration extends Collection {
    *   A StreamWrapperConfiguration object.
    */
   public static function fromDrupalVariables() {
-    $config = self::fromConfig(array('bucket' => static::variable_get('amazons3_bucket', NULL)));
+    $config = self::fromConfig(array(
+      'bucket' => static::variable_get('amazons3_bucket', NULL),
+      'region' => static::variable_get('amazons3_region', NULL)
+    ));
     $defaults = $config->defaults();
 
     $config->setHostname(static::variable_get('amazons3_hostname', $defaults['hostname']));

--- a/tests/S3ClientTest.php
+++ b/tests/S3ClientTest.php
@@ -22,6 +22,7 @@ class S3ClientTest extends GuzzleTestCase {
       'amazons3_key' => 'key',
       'amazons3_secret' => 'secret',
       'amazons3_hostname' => 'hostname',
+      'amazons3_region' => 'region',
     ]);
     DrupalS3Client::resetCalled();
     $client = DrupalS3Client::factory(array(), 'fake-bucket');
@@ -29,7 +30,7 @@ class S3ClientTest extends GuzzleTestCase {
     $this->assertEquals('key', $client->getCredentials()->getAccessKeyId());
     $this->assertEquals('secret', $client->getCredentials()->getSecretKey());
     $this->assertEquals('hostname', $client->getBaseUrl());
-    $this->assertTrue(DrupalS3Client::isGetBucketLocationCalled());
+    $this->assertEquals('region', $client->getRegion());
 
     DrupalS3Client::setVariableData(array());
   }

--- a/tests/StreamWrapperConfigurationTest.php
+++ b/tests/StreamWrapperConfigurationTest.php
@@ -17,7 +17,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    * @covers Drupal\amazons3\StreamWrapperConfiguration::required
    */
   public function testFromConfig() {
-    $settings = array('bucket' => 'bucket');
+    $settings = array('bucket' => 'bucket', 'region' => 'region');
     $config = StreamWrapperConfiguration::fromConfig($settings);
     $this->assertInstanceOf('Drupal\amazons3\StreamWrapperConfiguration', $config);
   }
@@ -43,7 +43,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    * @covers Drupal\amazons3\StreamWrapperConfiguration
    */
   public function testSetters() {
-    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket'));
+    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket', 'region' => 'region'));
 
     $config->setBucket('different-bucket');
     $this->assertEquals('different-bucket', $config->getBucket());
@@ -94,7 +94,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    * @expectedException \LogicException
    */
   public function testCacheLifetimeException() {
-    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket'));
+    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket', 'region' => 'region'));
     $config->setCacheLifetime(0);
   }
 
@@ -103,7 +103,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    * @expectedException \InvalidArgumentException
    */
   public function testCloudFrontCredentials() {
-    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket'));
+    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket', 'region' => 'region'));
     $config->setCloudFrontCredentials('/does-not-exist', 'asdf');
   }
 
@@ -112,7 +112,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    * @expectedException \LogicException
    */
   public function testCloudFrontNotSetUp() {
-    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket'));
+    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket', 'region' => 'region'));
     $config->getCloudFront();
   }
 
@@ -120,7 +120,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
    * @covers Drupal\amazons3\StreamWrapperConfiguration::fromConfig
    */
   public function testDefaultHostname() {
-    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket'));
+    $config = StreamWrapperConfiguration::fromConfig(array('bucket' => 'bucket', 'region' => 'region'));
     $this->assertEquals('bucket.s3.amazonaws.com', $config->getDomain());
   }
 
@@ -131,6 +131,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
   public function testFromDrupalVariables() {
     StreamWrapperConfiguration::setVariableData([
       'amazons3_bucket' => 'default.example.com',
+      'amazons3_region' => 'region',
       'amazons3_hostname' => 'api.example.com',
       'amazons3_cname' => TRUE,
       'amazons3_domain' => 'static.example.com',
@@ -158,6 +159,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
 
     StreamWrapperConfiguration::setVariableData([
       'amazons3_bucket' => 'default.example.com',
+      'amazons3_region' => 'region',
       'amazons3_cname' => TRUE,
       'amazons3_cache' => FALSE,
     ]);
@@ -168,6 +170,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
     // When the bucket has a dot, check that the bucket is not in the domain.
     StreamWrapperConfiguration::setVariableData([
       'amazons3_bucket' => 'default.example.com',
+      'amazons3_region' => 'region',
     ]);
     $config = StreamWrapperConfiguration::fromDrupalVariables();
     $this->assertEquals('s3.amazonaws.com', $config->getDomain());
@@ -176,6 +179,7 @@ class StreamWrapperConfigurationTest extends \PHPUnit_Framework_TestCase {
     // subdomain.
     StreamWrapperConfiguration::setVariableData([
       'amazons3_bucket' => 'bucket',
+      'amazons3_region' => 'region',
     ]);
     $config = StreamWrapperConfiguration::fromDrupalVariables();
     $this->assertEquals('bucket.s3.amazonaws.com', $config->getDomain());

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -36,6 +36,7 @@ class StreamWrapperTest extends GuzzleTestCase {
 
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
     ]);
@@ -63,6 +64,7 @@ class StreamWrapperTest extends GuzzleTestCase {
 
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
     ]);
     StreamWrapper::setDefaultConfig($config);
@@ -81,6 +83,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testConstructDefaultConfig() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'defaultconfig.example.com',
+      'region' => 'region',
       'caching' => FALSE,
     ]);
     StreamWrapper::setDefaultConfig($config);
@@ -98,6 +101,7 @@ class StreamWrapperTest extends GuzzleTestCase {
     StreamWrapper::setClient(null);
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'region' => 'us-east-1',
     ]);
@@ -113,6 +117,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testCreateCache() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => TRUE,
       'expiration' => 0,
     ]);
@@ -341,6 +346,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testBasename() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
     ]);
@@ -370,6 +376,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testSaveAs() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
       'saveAsPaths' => new MatchablePaths(BasicPath::factory(array('force-download/.*'))),
@@ -385,6 +392,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testSaveAsExcluded() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
       'saveAsPaths' => new MatchablePaths(BasicPath::factory(array('force-download/*'))),
@@ -404,6 +412,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testSaveAsAll() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
       'saveAsPaths' => new MatchablePaths(BasicPath::factory(array('*'))),
@@ -423,6 +432,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testAttachmentSpace() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
       'saveAsPaths' => new MatchablePaths(BasicPath::factory(array('force-download/.*'))),
@@ -443,6 +453,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testTorrentPath() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
       'torrentPaths' => new MatchablePaths(BasicPath::factory(array('torrents/.*'))),
@@ -461,6 +472,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testPresignedPath() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'expiration' => 0,
       'presignedPaths' => new MatchablePaths(PresignedPath::factory(array('presigned/.*' => 30))),
@@ -487,6 +499,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testCustomDomain() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'domain' => 'static.example.com',
       'caching' => FALSE,
       'expiration' => 0,
@@ -504,6 +517,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testNoCustomDomain() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
     ]);
     $wrapper = new StreamWrapper($config);
@@ -519,6 +533,7 @@ class StreamWrapperTest extends GuzzleTestCase {
   public function testReducedRedundancyStorage() {
     $config = StreamWrapperConfiguration::fromConfig([
       'bucket' => 'bucket.example.com',
+      'region' => 'region',
       'caching' => FALSE,
       'reducedRedundancyPaths' => new MatchablePaths(BasicPath::factory(array('*'))),
     ]);

--- a/tests/Stub/S3Client.php
+++ b/tests/Stub/S3Client.php
@@ -17,11 +17,9 @@ class S3Client extends \Drupal\amazons3\S3Client {
   use Bootstrap;
 
   protected static $factoryCalled = FALSE;
-  protected static $getBucketLocationCalled = FALSE;
 
   public static function resetCalled() {
     static::$factoryCalled = FALSE;
-    static::$getBucketLocationCalled = FALSE;
   }
 
   /**
@@ -29,13 +27,6 @@ class S3Client extends \Drupal\amazons3\S3Client {
    */
   public static function isFactoryCalled() {
     return static::$factoryCalled;
-  }
-
-  /**
-   * @return boolean
-   */
-  public static function isGetBucketLocationCalled() {
-    return self::$getBucketLocationCalled;
   }
 
   /**
@@ -60,11 +51,4 @@ class S3Client extends \Drupal\amazons3\S3Client {
     return parent::factory($config, $bucket);
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function getBucketLocation($bucket, AwsS3Client $client) {
-    static::$getBucketLocationCalled = TRUE;
-    return 'fake-region';
-  }
 }


### PR DESCRIPTION
See also #44 .

The one thing I did in this PR is make 'region' a required key when setting up an S3 client. This would only affect custom code and not configuring the module, and is certainly a compatibility break. I think it's a good call considering how broken EU regions are right now, but I'm open to arguments otherwise.
