### PR TITLE
remove checks dots in getS3Domain function to make S3 url works

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -251,6 +251,7 @@ class StreamWrapper extends \Aws\S3\StreamWrapper implements \DrupalStreamWrappe
 
       // Generate a standard URL.
       $url = $this->getS3Url($path, $expiry, $args);
+      $url->setPath('/'. $path);
     }
 
     return (string) $url;

--- a/src/StreamWrapperConfiguration.php
+++ b/src/StreamWrapperConfiguration.php
@@ -112,11 +112,8 @@ class StreamWrapperConfiguration extends Collection {
    */
   protected static function getS3Domain($bucket) {
     $domain = StreamWrapper::S3_API_DOMAIN;
-    // If the bucket does not contain dots, the S3 SDK generates URLs that
-    // use the bucket name in the host.
-    if (strpos($bucket, '.') === FALSE) {
-      $domain = $bucket . '.' . $domain;
-    }
+
+    $domain = $bucket . '.' . $domain;
 
     return $domain;
   }


### PR DESCRIPTION
## For some reason, when S3 bucket has dots in name (e.g: assets.domain.com), Amazons3 Module make S3URL wrong...

### Example: 
```https://s3.amazonaws.com/assets.domain.com/cat.jpeg``` 

`https://s3.amazonaws.com/{bucket_name}/cat.jpeg`

### New way is: 
`https://assets.domain.com.s3.amazonaws.com/cat.jpeg`

`https://[bucket_name].s3.amazonaws.com/cat.jpeg`

